### PR TITLE
feat: update node version and actions core

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: "Pull Request Updater GitHub Action"
 description: "GitHub Action that updates a pull request with information extracted from branch name"
 author: "Tamim Khan"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 inputs:
   repo-token:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/tzkhan/pr-update-action/#readme",
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.10.0",
     "@actions/github": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Cette PR permet de mettre à jour les versions de node et du package @actions/core vers 1.10.0 permettant ainsi de supprimer certains warnings :

* D'après [ce warning](https://github.com/croesusfin/croesus-installations/actions/runs/7561635942/job/20590332657#step:8:19), il faut mettre à jour le package @actions/core vers 1.10.0 minimum pour utiliser la nouvelle version de set-output (cf [Github changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))

* D'après [ce warning](https://github.com/croesusfin/croesus-installations/actions/runs/7561635942), il faut mettre à jour la version de node de 12 à 16 (cf [Github changelog](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/))


> :warning: Github indique que ces mises à jours requiert que nos self-hosted runners utilisent la version 2.297.0 ou plus. [source](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#patching-your-actions-and-workflows)